### PR TITLE
set worker to 4 to allow “reentrant” calls such as the controller cal…

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn bin.start_web:application
+web: gunicorn -w 4 bin.start_web:application


### PR DESCRIPTION
…ling openwhisk -> calling the controller back. With the default of 1 worker, such calls would always timeout.

#19